### PR TITLE
Refer to the meeting notes doc, add Jaakko as a maintainer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,11 +14,12 @@ _As contributors and maintainers of this project, and in the interest of fosteri
 
 ## Community and Access
 
-Join the [racklet@groups.io](https://groups.io/g/racklet) mailing list for calendar invites to calls and edit access to community documents.
 You can ask questions and discuss features on the [#racklet](https://osfw.slack.com/messages/racklet/) Slack channel (you can get an invite at [here](https://slack.osfw.dev/)).
 
 In the future, we are also planning to start public, recurring community meetings where anyone can join and
 participate in the discussion by adding an agenda item to a public meeting notes document.
+
+The community meeting notes document is [here](https://hackmd.io/@racklet/Sk8jHHc7_) (see also the [meeting-notes](https://github.com/racklet/meeting-notes) repo). Look out there for when the community meetings are, and follow the Slack channel.
 
 ## Guidelines
 
@@ -39,7 +40,7 @@ The process to contribute code to Racklet is generally as follows:
 3. Go back to [GitHub](https://github.com/racklet/racklet), select `Pull requests` from the top bar and click
    `New pull request` to the right. Select the `compare across forks` link. This will show repositories in addition to branches.
 4. From the `head repository` dropdown, select your forked repository. If you made a new branch, select it in the `compare` dropdown.
-   You should always target `racklet/racklet` and `main` as the base repository and branch.
+   You should always target `racklet/racklet` (or similar repository) and `main` as the base repository and branch.
 5. With your changes visible, click `Create pull request`. Give it a short, descriptive title and write a comment describing your changes.
    Click `Create pull request`.
 

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -5,5 +5,6 @@ the Open Source Firmware Slack (https://osfw.slack.com/messages/racklet/)
 In alphabetical order:
 
 Dennis Marttinen <twelho@welho.tech> (GitHub: @twelho, Slack: twelho)
+Jaakko Sirén <jaakko.siren@pm.me> (GitHub: @Jaakkonen, Slack: Jaakkonen)
 Lucas Käldström <lucas.kaldstrom@hotmail.co.uk> (GitHub: @luxas, Slack: luxas)
 Verneri Hirvonen <verneri.hirvonen.2@gmail.com> (GitHub: @chiplet, Slack: Verneri Hirvonen)

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Other interesting resources include:
 - [The issue tracker](https://github.com/racklet/racklet/issues)
 - [The discussions forum](https://github.com/racklet/racklet/discussions)
 - [The list of milestones](https://github.com/racklet/racklet/milestones)
-- _The roadmap (TODO)_
-- _The changelog (TODO)_
+- [The roadmap](https://github.com/orgs/racklet/projects/1)
+- [The changelog](https://github.com/racklet/racklet/blob/main/CHANGELOG.md)
 
 ## Getting Help
 
@@ -22,14 +22,16 @@ If you have any questions about, feedback for or problems with Racklet:
 - Ask a question on the [#racklet](https://osfw.slack.com/messages/racklet/) slack channel.
 - Ask a question on the [discussions forum](https://github.com/racklet/racklet/discussions).
 - [File an issue](https://github.com/racklet/racklet/issues/new).
-- Join [racklet@groups.io](https://groups.io/g/racklet) for calendar invites to calls and edit access to community documents.
-- Join our _developer meetings (TODO)_.
+- Join our [community meetings](https://hackmd.io/@racklet/Sk8jHHc7_) (see also the [meeting-notes](https://github.com/racklet/meeting-notes) repo).
 
 Your feedback is always welcome!
 
 ## Maintainers
 
+In alphabetical order:
+
 - Dennis Marttinen, [@twelho](https://github.com/twelho)
+- Jaakko Sirén, [@Jaakkonen](https://github.com/Jaakkonen)
 - Lucas Käldström, [@luxas](https://github.com/luxas)
 - Verneri Hirvonen, [@chiplet](https://github.com/chiplet)
 


### PR DESCRIPTION
Remove the mention of the mailing list, we just might not need it.
I made a meeting notes doc now that's pointing at the `meeting-notes` repo, that we can use for meetings, instead of Google Docs.
We can sync it to GH every now and then, which is great. Everyone can edit the HackMD file.

Put up the pointer to the project management board of this organization.
Adding Jaakko to the maintainers list.