### PR TITLE
Change which KiCad files are tracked by git LFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,5 +14,4 @@
 
 # Electronics Design (KiCad)
 *.kicad_pcb filter=lfs diff=lfs merge=lfs -text
-*.sch filter=lfs diff=lfs merge=lfs -text
 *.kicad_mod filter=lfs diff=lfs merge=lfs -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -12,8 +12,7 @@
 *.step filter=lfs diff=lfs merge=lfs -text
 *.FCStd* filter=lfs diff=lfs merge=lfs -text
 
-# Schematics (KiCad)
+# Electronics Design (KiCad)
 *.kicad_pcb filter=lfs diff=lfs merge=lfs -text
-*.pro filter=lfs diff=lfs merge=lfs -text
-*.lib filter=lfs diff=lfs merge=lfs -text
-*.dcm filter=lfs diff=lfs merge=lfs -text
+*.sch filter=lfs diff=lfs merge=lfs -text
+*.kicad_mod filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
This PR changes which files are being tracked by git LFS. Most notably the following changes are made:
1. Files untracked from LFS:
  * `.pro` -- KiCad project files
  * `.lib` -- symbol libraries
  * `.dcm` -- symbol library documentation
2. Files tracked to LFS:
  * `.kicad_pcb` -- PCB save files
  * `.sch` -- schematic save files
  * `.kicad_mod` -- footprint files

In general all KiCad files seem to be plain-text. The untracked files are small or otherwise contain information that's useful to see in git diffs. The files tracked into LFS are machine generated unreadable plain-text files that can be very large in size.

Some additional notes about the different file formats have been written [here](https://github.com/racklet/racklet-kicad-lib/issues/7#issuecomment-910381718).